### PR TITLE
Update inactive users report to pull full report.

### DIFF
--- a/InactiveUsersLast90Days.ps1
+++ b/InactiveUsersLast90Days.ps1
@@ -14,8 +14,13 @@ $endDate = (Get-Date).ToString('MM/dd/yyyy')
 $allUsers = @()
 $allUsers = Get-MsolUser -All -EnabledFilter EnabledOnly | Select UserPrincipalName
 
+$PageCounter=1 #Set it to 1 initially since we will start with the first page.
 $loggedOnUsers = @()
-$loggedOnUsers = Search-UnifiedAuditLog -StartDate $startDate -EndDate $endDate -Operations UserLoggedIn, PasswordLogonInitialAuthUsingPassword, UserLoginFailed -ResultSize 5000
+Do{
+    Write-Verbose -Message "Pulling Page $PageCounter"
+    $loggedOnUsers += Search-UnifiedAuditLog -StartDate $startDate -EndDate $endDate -Operations UserLoggedIn, PasswordLogonInitialAuthUsingPassword, UserLoginFailed -ResultSize 5000 -SessionId "Inactive Users Report - 90 days" -SessionCommand ReturnNextPreviewPage
+    $PageCounter++
+}While($loggedOnUsers.count%5000 -eq 0) #Since the command will return 5000 results at once, the modulo should always be 0 until we get the last set.
 
 $inactiveInLastThreeMonthsUsers = @()
 $inactiveInLastThreeMonthsUsers = $allUsers.UserPrincipalName | where {$loggedOnUsers.UserIds -NotContains $_}


### PR DESCRIPTION
This update should pull the full report in chunks of 5000 (page size maximum).
Fixes #5