### PR TITLE
Add  -NoClobber -NoTypeInformation to the CSV export

### DIFF
--- a/DumpDelegatesandForwardingRules.ps1
+++ b/DumpDelegatesandForwardingRules.ps1
@@ -25,6 +25,6 @@ foreach ($User in $allUsers)
 
 $SMTPForwarding = Get-Mailbox -ResultSize Unlimited | select DisplayName,ForwardingAddress,ForwardingSMTPAddress,DeliverToMailboxandForward | where {$_.ForwardingSMTPAddress -ne $null}
 
-$UserInboxRules | Export-Csv MailForwardingRulesToExternalDomains.csv
-$UserDelegates | Export-Csv MailboxDelegatePermissions.csv
-$SMTPForwarding | Export-Csv Mailboxsmtpforwarding.csv
+$UserInboxRules | Export-Csv MailForwardingRulesToExternalDomains.csv -NoClobber -NoTypeInformation
+$UserDelegates | Export-Csv MailboxDelegatePermissions.csv -NoClobber -NoTypeInformation
+$SMTPForwarding | Export-Csv Mailboxsmtpforwarding.csv -NoClobber -NoTypeInformation


### PR DESCRIPTION
This change will ensure that the scripts cannot overwrite previous versions of the CSV reports (so that you can easily keep a version history) and remove the #Type headers from the CSV file as well, which makes is easier to filter in Excel