### PR TITLE
Fix typo with RedirectTo

### DIFF
--- a/DumpDelegatesandForwardingRules.ps1
+++ b/DumpDelegatesandForwardingRules.ps1
@@ -19,7 +19,7 @@ $UserDelegates = @()
 foreach ($User in $allUsers)
 {
     Write-Host "Checking inbox rules and delegates for user: " $User.UserPrincipalName;
-    $UserInboxRules += Get-InboxRule -Mailbox $User.UserPrincipalname | Select Name, Description, Enabled, Priority, ForwardTo, ForwardAsAttachmentTo, RedirectTo, DeleteMessage | Where-Object {($_.ForwardTo -ne $null) -or ($_.ForwardAsAttachmentTo -ne $null) -or ($_.RedirectsTo -ne $null)}
+    $UserInboxRules += Get-InboxRule -Mailbox $User.UserPrincipalname | Select Name, Description, Enabled, Priority, ForwardTo, ForwardAsAttachmentTo, RedirectTo, DeleteMessage | Where-Object {($_.ForwardTo -ne $null) -or ($_.ForwardAsAttachmentTo -ne $null) -or ($_.RedirectTo -ne $null)}
     $UserDelegates += Get-MailboxPermission -Identity $User.UserPrincipalName | Where-Object {($_.IsInherited -ne "True") -and ($_.User -notlike "*SELF*")}
 }
 


### PR DESCRIPTION
The script is missing RedirectTo rules with the small typo