### PR TITLE
Removed getting al users

### DIFF
--- a/DumpDelegatesandForwardingRules.ps1
+++ b/DumpDelegatesandForwardingRules.ps1
@@ -4,26 +4,23 @@ import-module MSOnline
 #Let's get us an admin cred!
 $userCredential = Get-Credential
 
-#This connects to Azure Active Directory
-Connect-MsolService -Credential $userCredential
-
 $ExoSession = New-PSSession -ConfigurationName Microsoft.Exchange -ConnectionUri https://outlook.office365.com/powershell-liveid/ -Credential $userCredential -Authentication Basic -AllowRedirection
 Import-PSSession $ExoSession
 
-$allUsers = @()
-$AllUsers = Get-MsolUser -All -EnabledFilter EnabledOnly | select ObjectID, UserPrincipalName, FirstName, LastName, StrongAuthenticationRequirements, StsRefreshTokensValidFrom, StrongPasswordRequired, LastPasswordChangeTimestamp | Where-Object {($_.UserPrincipalName -notlike "*#EXT#*")}
+#Get all mailboxes
+$mailboxes = Get-Mailbox -ResultSize Unlimited
 
 $UserInboxRules = @()
 $UserDelegates = @()
+$SMTPForwarding = @()
 
-foreach ($User in $allUsers)
+foreach ($mailbox in $mailboxes)
 {
-    Write-Host "Checking inbox rules and delegates for user: " $User.UserPrincipalName;
-    $UserInboxRules += Get-InboxRule -Mailbox $User.UserPrincipalname | Select Name, Description, Enabled, Priority, ForwardTo, ForwardAsAttachmentTo, RedirectTo, DeleteMessage | Where-Object {($_.ForwardTo -ne $null) -or ($_.ForwardAsAttachmentTo -ne $null) -or ($_.RedirectsTo -ne $null)}
-    $UserDelegates += Get-MailboxPermission -Identity $User.UserPrincipalName | Where-Object {($_.IsInherited -ne "True") -and ($_.User -notlike "*SELF*")}
+    Write-Host "Checking inbox rules and delegates for user: " $mailbox.UserPrincipalName;
+    $UserInboxRules += Get-InboxRule -Mailbox $mailbox.UserPrincipalname | Select Name, Description, Enabled, Priority, ForwardTo, ForwardAsAttachmentTo, RedirectTo, DeleteMessage | Where-Object {($_.ForwardTo -ne $null) -or ($_.ForwardAsAttachmentTo -ne $null) -or ($_.RedirectsTo -ne $null)}
+    $UserDelegates += Get-MailboxPermission -Identity $mailbox.UserPrincipalName | Where-Object {($_.IsInherited -ne "True") -and ($_.User -notlike "*SELF*")}
+    $SMTPForwarding += $mailbox | select DisplayName,ForwardingAddress,ForwardingSMTPAddress,DeliverToMailboxandForward | where {$_.ForwardingSMTPAddress -ne $null}
 }
-
-$SMTPForwarding = Get-Mailbox -ResultSize Unlimited | select DisplayName,ForwardingAddress,ForwardingSMTPAddress,DeliverToMailboxandForward | where {$_.ForwardingSMTPAddress -ne $null}
 
 $UserInboxRules | Export-Csv MailForwardingRulesToExternalDomains.csv
 $UserDelegates | Export-Csv MailboxDelegatePermissions.csv


### PR DESCRIPTION
Removed the part that will get all users, not every user will have a mailbox, so this will give several errors.
It also only got the enabled accounts, a shared mailbox is by default a disabled account so those will not be checked and can have these rights on it.

Converted it to get every mailbox and get it from there.