### PR TITLE
Get-AllTenantRulesAndForms.ps1: Use -ResultSize Unlimited

### DIFF
--- a/Get-AllTenantRulesAndForms.ps1
+++ b/Get-AllTenantRulesAndForms.ps1
@@ -159,7 +159,7 @@ Import-PSSession $ExoSession
 
 
 #Get all the mailboxes
-$mailBoxes = Get-Mailbox | Select UserPrincipalName
+$mailBoxes = Get-Mailbox -ResultSize Unlimited | Select UserPrincipalName
 ("Number of mailboxes to process: " + $mailBoxes.Count.ToString())
 
 #For Every Mailbox, get all the rules and dump them to a big file


### PR DESCRIPTION
Getting all mailboxes instead of only 1000 does not appear to cause any issues. Tested on a tenant with over 50,000 users.