### PR TITLE
fixed minor grammar error. using -UPN parameter

### DIFF
--- a/InactiveUsersLast90Days.ps1
+++ b/InactiveUsersLast90Days.ps1
@@ -1,11 +1,15 @@
-﻿#Import MSOline Module
- import-module MSOnline
- #Import Exchange Online Module
- Import-Module $((Get-ChildItem -Path $($env:LOCALAPPDATA + "\Apps\2.0\") -Filter Microsoft.Exchange.Management.ExoPowershellModule.dll -Recurse).FullName | ?{ $_ -notmatch "_none_" } | select -First 1)
+﻿# Set and check for presence of -admin parameter holding admin UPN
+param ($UPN)
 
+If ($null -eq $UPN) {
+  Write-Host "Script requires a -UPN parameter"
+  exit
+}
 
-#Set admin UPN
-$UPN = 'user@domain.com'
+#Import MSOline Module
+import-module MSOnline
+#Import Exchange Online Module
+Import-Module $((Get-ChildItem -Path $($env:LOCALAPPDATA + "\Apps\2.0\") -Filter Microsoft.Exchange.Management.ExoPowershellModule.dll -Recurse).FullName | Where-Object{ $_ -notmatch "_none_" } | Select-Object -First 1)
 
 #This connects to Azure Active Directory & Exchange Online
 Connect-MsolService
@@ -16,14 +20,13 @@ $startDate = (Get-Date).AddDays(-90).ToString('MM/dd/yyyy')
 $endDate = (Get-Date).ToString('MM/dd/yyyy')
 
 $allUsers = @()
-$allUsers = Get-MsolUser -All -EnabledFilter EnabledOnly | Select UserPrincipalName
+$allUsers = Get-MsolUser -All -EnabledFilter EnabledOnly | Select-Object UserPrincipalName
 
 $loggedOnUsers = @()
 $loggedOnUsers = Search-UnifiedAuditLog -StartDate $startDate -EndDate $endDate -Operations UserLoggedIn, PasswordLogonInitialAuthUsingPassword, UserLoginFailed -ResultSize 5000
 
 $inactiveInLastThreeMonthsUsers = @()
-$inactiveInLastThreeMonthsUsers = $allUsers.UserPrincipalName | where {$loggedOnUsers.UserIds -NotContains $_}
+$inactiveInLastThreeMonthsUsers = $allUsers.UserPrincipalName | Where-Object {$loggedOnUsers.UserIds -NotContains $_}
 
-Write-Output "The following users have no logged in for the last 90 days:"
+Write-Output "The following users have not logged in for the last 90 days:"
 Write-Output $inactiveInLastThreeMonthsUsers
-


### PR DESCRIPTION
There are 3 changes proposed in this pull request:

- Update of Select and Where-Object keywords
- Update of a minor grammar error
- Implementation of a -UPN parameter to the admin's UPN does not have to be stored in the file

Thanks for considering it.